### PR TITLE
fixed read function bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # to install type:
 # python setup.py install --root=/
 def readme():
-    with open('README.rst') as f:
+    with open('README.rst', encoding="utf8") as f:
         return f.read()
 setup (name='Tashaphyne', version='0.3.4.1',
       description='Tashaphyne Arabic Light Stemmer',


### PR DESCRIPTION
Fixed the `read` function in `setup.py` as the encoding was not explicitly defined and that resulted in error while installing with `pip`.

The error was as follows during `pip install tashaphyne`: 
`UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 301: character maps to <undefined>`

Now the error is resolved.